### PR TITLE
Fix Endian constants for pymodbus 3.6.5

### DIFF
--- a/modbus_driver.py
+++ b/modbus_driver.py
@@ -8,8 +8,8 @@ from pymodbus.payload import BinaryPayloadBuilder, BinaryPayloadDecoder
 
 import registers as REG
 
-BYTEORDER = Endian.Little
-WORDORDER = Endian.Big
+BYTEORDER = Endian.LITTLE
+WORDORDER = Endian.BIG
 
 
 class VSensorDriver:


### PR DESCRIPTION
## Summary
- ensure pymodbus 3.6.5 works by switching to Endian.LITTLE/BIG

## Testing
- `pip install -r requirements.txt`
- `timeout 5 python app.py`

------
https://chatgpt.com/codex/tasks/task_e_68b1a22f1c6483339de06f86a9321f83