### PR TITLE
Guard single Modbus connection and move startup logic into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# modbus
+## modbus
+
+Dash-Anwendung zum Auslesen und Steuern eines V‑Sensors über Modbus.
+
+### Start
+
+```
+python app.py
+```
+
+Die serielle Verbindung wird dabei nur einmal geöffnet; beim Import von
+`app.py` treten keine Nebenwirkungen auf.


### PR DESCRIPTION
## Summary
- open Modbus serial connection only once with a startup guard and global lock
- move driver connect and polling thread into `__main__` and disable Dash reloader
- document how to start the app

## Testing
- `python -m py_compile app.py modbus_driver.py config.py registers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1af7119748333bf5928f9a02398fd