### PR TITLE
Überarbeite Dash-Oberfläche und Styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,95 +47,236 @@ def poller() -> None:
 
 app = Dash(__name__)
 app.layout = html.Div(
-    [
-        html.H2("V-Sensor Dashboard"),
-        html.Div(
-            [
-                dcc.Input(id="cfg_port", type="text", value=CFG["PORT"], placeholder="Port"),
-                dcc.Input(
-                    id="cfg_slave",
-                    type="number",
-                    value=CFG["SLAVE_ID"],
-                    placeholder="Slave-ID",
-                    min=1,
-                ),
-                dcc.Input(
-                    id="cfg_baud",
-                    type="number",
-                    value=CFG["BAUD"],
-                    placeholder="Baud",
-                    min=1200,
-                ),
-                dcc.Dropdown(
-                    id="cfg_parity",
-                    options=[{"label": p, "value": p} for p in ["N", "E", "O"]],
-                    value=CFG["PARITY"],
-                    clearable=False,
-                ),
-                dcc.Input(
-                    id="cfg_stopbits",
-                    type="number",
-                    value=CFG["STOPBITS"],
-                    placeholder="Stopbits",
-                    min=1,
-                    max=2,
-                ),
-                dcc.Dropdown(
-                    id="cfg_ff",
-                    options=[{"label": str(i), "value": i} for i in range(4)],
-                    value=CFG["FLOAT_FORMAT"],
-                    clearable=False,
-                ),
-                html.Button("Verbinden/Übernehmen", id="btn_connect"),
-            ]
+    className="container",
+    children=[
+        dcc.Loading(
+            type="circle",
+            children=html.Div(
+                className="card connection",
+                children=[
+                    html.Div(
+                        className="conn-fields",
+                        children=[
+                            html.Div(
+                                [
+                                    html.Label(
+                                        "Port",
+                                        htmlFor="cfg_port",
+                                        title="Serieller Port, z.B. /dev/ttyUSB0",
+                                    ),
+                                    dcc.Input(
+                                        id="cfg_port",
+                                        type="text",
+                                        value=CFG["PORT"],
+                                        placeholder="/dev/ttyUSB0",
+                                    ),
+                                ]
+                            ),
+                            html.Div(
+                                [
+                                    html.Label(
+                                        "Slave-ID",
+                                        htmlFor="cfg_slave",
+                                        title="Adresse des V-Sensors, Standard 1–247",
+                                    ),
+                                    dcc.Input(
+                                        id="cfg_slave",
+                                        type="number",
+                                        value=CFG["SLAVE_ID"],
+                                        min=1,
+                                        max=247,
+                                        placeholder="1–247",
+                                    ),
+                                ]
+                            ),
+                            html.Div(
+                                [
+                                    html.Label(
+                                        "Baudrate",
+                                        htmlFor="cfg_baud",
+                                        title="Übertragungsgeschwindigkeit",
+                                    ),
+                                    dcc.Input(
+                                        id="cfg_baud",
+                                        type="number",
+                                        value=CFG["BAUD"],
+                                        min=1200,
+                                        placeholder="9600",
+                                    ),
+                                ]
+                            ),
+                            html.Div(
+                                [
+                                    html.Label(
+                                        "Parität",
+                                        htmlFor="cfg_parity",
+                                        title="N = none, E = even, O = odd",
+                                    ),
+                                    dcc.Dropdown(
+                                        id="cfg_parity",
+                                        options=[{"label": p, "value": p} for p in ["N", "E", "O"]],
+                                        value=CFG["PARITY"],
+                                        clearable=False,
+                                    ),
+                                ]
+                            ),
+                            html.Div(
+                                [
+                                    html.Label(
+                                        "Stopbits",
+                                        htmlFor="cfg_stopbits",
+                                        title="Anzahl Stopbits",
+                                    ),
+                                    dcc.Input(
+                                        id="cfg_stopbits",
+                                        type="number",
+                                        value=CFG["STOPBITS"],
+                                        min=1,
+                                        max=2,
+                                        placeholder="1",
+                                    ),
+                                ]
+                            ),
+                            html.Div(
+                                [
+                                    html.Label(
+                                        "Float-Format",
+                                        htmlFor="cfg_ff",
+                                        title="0–3, Byte-Reihenfolge des Sensors",
+                                    ),
+                                    dcc.Dropdown(
+                                        id="cfg_ff",
+                                        options=[{"label": str(i), "value": i} for i in range(4)],
+                                        value=CFG["FLOAT_FORMAT"],
+                                        clearable=False,
+                                    ),
+                                ]
+                            ),
+                            html.Button("Verbinden/Übernehmen", id="btn_connect", className="btn"),
+                        ],
+                    ),
+                    html.Span(id="status", className="badge disconnected"),
+                ],
+            ),
         ),
-        html.Div(["Status: ", html.Span(id="status")]),
-        html.Div(["Druck [Pa]: ", html.Span(id="pressure")]),
-        html.Div(["Ausgang [%]: ", html.Span(id="output")]),
-        html.Div(["Auto-Sollwert: ", html.Span(id="auto_sp")]),
-        html.Div(["Modus: ", html.Span(id="mode")]),
-        html.Div(["Heartbeat: ", html.Span(id="hb")]),
-        html.Hr(),
         html.Div(
-            [
-                dcc.Input(
-                    id="new_sp",
-                    type="number",
-                    placeholder="Auto-Sollwert",
-                    min=0,
-                ),
-                html.Button("Setze Auto-Sollwert", id="btn_set_sp"),
-            ]
-        ),
-        html.Div(
-            [
-                dcc.Input(
-                    id="new_sp_hand",
-                    type="number",
-                    placeholder="Hand-Sollwert",
-                    min=0,
-                    max=100,
-                ),
-                html.Button("Setze Hand-Sollwert", id="btn_set_hand"),
-            ]
-        ),
-        html.Div(
-            [
-                dcc.Dropdown(
-                    id="mode_dd",
-                    options=[
-                        {"label": "AUTO", "value": 1},
-                        {"label": "HAND @SP", "value": 2},
-                        {"label": "OFF", "value": 3},
-                        {"label": "HAND @Output", "value": 4},
+            className="main-grid",
+            children=[
+                html.Div(
+                    className="card",
+                    children=[
+                        html.H3("Live-Werte"),
+                        html.Div(
+                            className="live-grid",
+                            children=[
+                                html.Div(
+                                    className="mini-card",
+                                    children=[
+                                        html.Div(id="auto_sp", className="value"),
+                                        html.Div("Displaywert", className="label"),
+                                    ],
+                                ),
+                                html.Div(
+                                    className="mini-card",
+                                    children=[
+                                        html.Div(id="pressure", className="value"),
+                                        html.Div("Druck [Pa]", className="label"),
+                                    ],
+                                ),
+                                html.Div(
+                                    className="mini-card",
+                                    children=[
+                                        html.Div(id="output", className="value"),
+                                        html.Div("Ausgang [%]", className="label"),
+                                    ],
+                                ),
+                                html.Div(
+                                    className="mini-card",
+                                    children=[
+                                        html.Div(id="mode", className="value"),
+                                        html.Div("Modus", className="label"),
+                                    ],
+                                ),
+                                html.Div(
+                                    className="mini-card",
+                                    children=[
+                                        html.Div(id="hb", className="value"),
+                                        html.Div("Heartbeat", className="label"),
+                                    ],
+                                ),
+                            ],
+                        ),
                     ],
-                    value=1,  # Default: AUTO
                 ),
-                html.Button("Setze Modus", id="btn_set_mode"),
-            ]
+                html.Div(
+                    className="card",
+                    children=[
+                        html.H3("Steuerung"),
+                        html.Div(
+                            className="ctrl-field",
+                            children=[
+                                html.Label(
+                                    "Auto-Sollwert",
+                                    htmlFor="new_sp",
+                                    title="Sollwert im Automatikmodus",
+                                ),
+                                dcc.Input(
+                                    id="new_sp",
+                                    type="number",
+                                    min=0,
+                                    max=5000,
+                                    placeholder="0–5000",
+                                ),
+                                html.Button("Setze Auto-Sollwert", id="btn_set_sp", className="btn"),
+                            ],
+                        ),
+                        html.Div(
+                            className="ctrl-field",
+                            children=[
+                                html.Label(
+                                    "Hand-Soll [%]",
+                                    htmlFor="new_sp_hand",
+                                    title="Sollwert im Handbetrieb",
+                                ),
+                                dcc.Input(
+                                    id="new_sp_hand",
+                                    type="number",
+                                    min=0,
+                                    max=100,
+                                    placeholder="0–100",
+                                ),
+                                html.Button("Setze Hand-Sollwert", id="btn_set_hand", className="btn"),
+                            ],
+                        ),
+                        html.Div(
+                            className="ctrl-field",
+                            children=[
+                                dcc.Dropdown(
+                                    id="mode_dd",
+                                    options=[
+                                        {"label": "AUTO", "value": 1},
+                                        {"label": "HAND@SP", "value": 2},
+                                        {"label": "OFF", "value": 3},
+                                        {"label": "HAND@Output", "value": 4},
+                                    ],
+                                    value=1,
+                                    clearable=False,
+                                ),
+                                html.Button("Setze Modus", id="btn_set_mode", className="btn"),
+                            ],
+                        ),
+                        html.Div(id="msg", className="msg"),
+                    ],
+                ),
+            ],
+        ),
+        html.Div(
+            "9600 8N1, RS-485 2-Draht; Float-Format 0–3 siehe Handbuch",
+            className="hint",
         ),
         dcc.Interval(id="tick", interval=1000, n_intervals=0),
-    ]
+        html.Div(id="toast", className="toast"),
+    ],
 )
 
 
@@ -152,9 +293,18 @@ def update_view(_):
     def fmt(v, f="{:.2f}"):
         return f.format(v) if isinstance(v, (int, float)) else "—"
 
-    mode_map = {1: "AUTO", 2: "HAND @SP", 3: "OFF", 4: "HAND @Output"}
-    status_map = {"ok": "verbunden"}
-    status_txt = status_map.get(shared["status"], shared["status"])
+    mode_map = {1: "AUTO", 2: "HAND@SP", 3: "OFF", 4: "HAND@Output"}
+    stat = shared.get("status")
+    if stat == "ok":
+        status_txt = "Verbunden"
+    elif stat == "connecting":
+        status_txt = "Verbinden…"
+    elif stat in {"init"}:
+        status_txt = "Getrennt"
+    else:
+        status_txt = f"Fehler ({stat})"
+    params = f"{CFG['PORT']}, ID {CFG['SLAVE_ID']}, FF {CFG['FLOAT_FORMAT']}"
+    status_full = f"{status_txt} – {params}"
     return (
         fmt(shared["pressure_pa"], "{:.1f}"),
         (fmt(shared["output_pct"], "{:.1f}") + " %")
@@ -163,7 +313,7 @@ def update_view(_):
         fmt(shared["auto_sp"], "{:.1f}"),
         mode_map.get(shared["mode"], "—"),
         shared["hb"] if isinstance(shared["hb"], int) else "—",
-        status_txt,
+        status_full,
     )
 
 
@@ -174,7 +324,8 @@ def update_view(_):
     prevent_initial_call=True,
 )
 def set_sp(_, val):
-    if val is None:
+    if val is None or not (0 <= float(val) <= 5000):
+        shared["status"] = "invalid"
         return 0
     try:
         with DRV_LOCK:
@@ -194,7 +345,8 @@ def set_sp(_, val):
     prevent_initial_call=True,
 )
 def set_hand(_, val):
-    if val is None:
+    if val is None or not (0 <= float(val) <= 100):
+        shared["status"] = "invalid"
         return 0
     try:
         with DRV_LOCK:
@@ -220,6 +372,7 @@ def set_hand(_, val):
 )
 def reconnect(_, port, slave, baud, parity, stopbits, ff):
     global DRV, CFG, poll_thread, stop_event
+    shared["status"] = "connecting"
     cfg = {
         "PORT": port or CFG["PORT"],
         "SLAVE_ID": int(slave) if slave is not None else CFG["SLAVE_ID"],
@@ -266,7 +419,8 @@ def reconnect(_, port, slave, baud, parity, stopbits, ff):
     prevent_initial_call=True,
 )
 def set_mode(_, val):
-    if val is None:
+    if val is None or int(val) not in {1, 2, 3, 4}:
+        shared["status"] = "invalid"
         return 0
     try:
         with DRV_LOCK:
@@ -277,6 +431,45 @@ def set_mode(_, val):
     except Exception as exc:  # pragma: no cover - debugging
         shared["status"] = f"err: {exc}"  # pragma: no cover
     return 0
+
+
+@app.callback(
+    Output("new_sp", "disabled"),
+    Output("btn_set_sp", "disabled"),
+    Output("new_sp_hand", "disabled"),
+    Output("btn_set_hand", "disabled"),
+    Output("mode_dd", "disabled"),
+    Output("btn_set_mode", "disabled"),
+    Input("tick", "n_intervals"),
+)
+def toggle_controls(_):
+    connected = shared.get("status") == "ok"
+    disabled = [not connected] * 6
+    return disabled
+
+
+@app.callback(
+    Output("status", "className"),
+    Input("tick", "n_intervals"),
+)
+def status_class(_):
+    return "badge connected" if shared.get("status") == "ok" else "badge disconnected"
+
+
+@app.callback(
+    Output("toast", "children"),
+    Output("toast", "className"),
+    Output("msg", "children"),
+    Input("tick", "n_intervals"),
+)
+def feedback(_):
+    stat = shared.get("status")
+    if stat == "write ok":
+        shared["status"] = "ok"
+        return "Wert geschrieben", "toast show", ""
+    if stat in {"timeout", "invalid"} or str(stat).startswith("err"):
+        return "", "toast", f"Fehler: {stat}"
+    return "", "toast", ""
 
 
 if __name__ == "__main__":

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,127 @@
+body {
+  font-family: sans-serif;
+  font-size: 16px;
+  margin: 0;
+  padding: 1rem;
+  background: #f5f5f5;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.card {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  margin-bottom: 1rem;
+}
+
+.connection {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+.conn-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  flex: 1;
+}
+.conn-fields > div {
+  display: flex;
+  flex-direction: column;
+}
+
+.main-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+@media (min-width: 900px) {
+  .main-grid {
+    grid-template-columns: 2fr 1fr;
+  }
+}
+
+.live-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+}
+.mini-card {
+  text-align: center;
+  padding: 0.5rem;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+.value {
+  font-size: 2rem;
+}
+.label {
+  font-size: 0.875rem;
+  color: #555;
+}
+
+.ctrl-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.btn {
+  padding: 0.4rem 0.8rem;
+  border: none;
+  border-radius: 4px;
+  background: #007bff;
+  color: #fff;
+  cursor: pointer;
+}
+.btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+}
+
+.badge {
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.875rem;
+}
+.badge.connected {
+  background: #28a745;
+}
+.badge.disconnected {
+  background: #dc3545;
+}
+
+.toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: #333;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+.toast.show {
+  opacity: 1;
+}
+
+.msg {
+  color: #dc3545;
+  min-height: 1.2rem;
+}
+
+.hint {
+  font-size: 0.75rem;
+  color: #666;
+  text-align: center;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- redesign dashboard with Verbindung card, Live-Werte grid, and Steuerung controls
- add responsive CSS and feedback callbacks for toasts and disabled controls

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a0f7c04083339a9ec8fa5bba4968