### PR TITLE
Uppercase dashboard config keys

### DIFF
--- a/apps/dashboard.py
+++ b/apps/dashboard.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=logging.DEBUG if os.getenv("VSENSOR_DEBUG") else loggi
 logger = logging.getLogger(__name__)
 
 # Defaults from environment
-CFG = asdict(Config.from_env())
+CFG = {k.upper(): v for k, v in asdict(Config.from_env()).items()}
 
 _client: Optional[VSensorClient] = None
 


### PR DESCRIPTION
## Summary
- Normalize dashboard configuration keys to uppercase for consistency

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'Endian' from 'pymodbus.constants'; ImportError: cannot import name 'ModbusSlaveContext' from 'pymodbus.datastore')*

------
https://chatgpt.com/codex/tasks/task_e_68b70049d3788333889562f2b8d7d81e