### PR TITLE
refactor: lazy vsensor client and cleanup state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ packages = ["vsensor"]
 vsensor = "vsensor.__main__:main"
 
 [tool.pytest.ini_options]
-addopts = "-q"
+addopts = "-q -m 'not hardware'"
+markers = ["hardware: tests requiring hardware"]
 
 [tool.ruff]
 line-length = 88
@@ -25,3 +26,5 @@ line-length = 88
 [tool.mypy]
 python_version = "3.10"
 ignore_missing_imports = true
+strict = true
+files = ["vsensor"]


### PR DESCRIPTION
## Summary
- defer VSensorClient transport setup until explicit connect
- remove module-level side effects and globals in dashboard
- configure mypy/pytest, mark hardware tests, support fake transport

## Testing
- `ruff check --fix .`
- `mypy`
- `PYTHONPATH=. pytest`
- `python -m vsensor --help`
- `VSENSOR_FAKE=1 python -m vsensor read telemetry`
- `VSENSOR_FAKE=1 python -m apps.dashboard`

------
https://chatgpt.com/codex/tasks/task_e_68b702bd66948333ac8b22b4a9be3d5a